### PR TITLE
Update parameter position in Find-StringInRepo.ps1

### DIFF
--- a/powershell/Find-StringInRepo.ps1
+++ b/powershell/Find-StringInRepo.ps1
@@ -18,7 +18,7 @@ Version: 1.0
 #>
 
 param (
-    [Parameter(Mandatory = $true)]
+    [Parameter(Position = 0, Mandatory = $true)]
     [string]$FilePath
 )
 


### PR DESCRIPTION
This pull request updates the parameter position in the Find-StringInRepo.ps1 file. The parameter was moved from its previous position to position 0 to simplify calling the script.