### PR TITLE
Fix PowerShell module import and installation

### DIFF
--- a/powershell/Update-NAVApp.ps1
+++ b/powershell/Update-NAVApp.ps1
@@ -32,10 +32,14 @@ param(
     [switch]$ForceSync
 )
 
-##  ===  Prepare PowerShell vor default BC18 installation
+##  ===  Prepare PowerShell for default BC18 installation
 
 Set-ExecutionPolicy unrestricted -Force
-Import-Module 'C:\Program Files\Microsoft Dynamics 365 Business Central\200\Service\NavAdminTool.ps1'
+if (!Get-Module -ListAvailable -Name 'Cloud.Ready.Software.NAV'){
+    Write-Host 'Cloud.Ready.Sofware.NAV module is missing. Installing the module...' -ForegroundColor Yellow
+    Install-Module -Name 'Cloud.Ready.Software.NAV'
+}
+Import-NAVModules
 
 ## ===  Color description  ======================
 


### PR DESCRIPTION
This pull request fixes the PowerShell module import and installation process for default BC18 installation. It ensures that the Cloud.Ready.Software.NAV module is installed if it is missing and imports the NAV modules.