### PR TITLE
Add Import-LatestNAVLicense.ps1 script for importing the latest NAV license file

### DIFF
--- a/powershell/Import-LatestNAVLicense.ps1
+++ b/powershell/Import-LatestNAVLicense.ps1
@@ -1,0 +1,46 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$serverInstance,
+  [Parameter(Mandatory = $true)]
+  [string]$licensePath
+)
+
+function Get-LatestLicenseFile() {
+  param(
+    [Parameter(Mandatory = $true)]
+    $licenseFiles
+  )
+  if (-not $licenseFiles) {
+    Write-Host "No license files found in '$licensePath'."
+    exit 1
+  }
+  if ($licenseFiles.Count -eq 1) {
+    return $licenseFiles[0].FullName
+  }
+  else {
+    $latestExpiryDate = $null
+    $latestFile = $null
+    $licenseFiles | ForEach-Object {
+      $licenseFileName = $_.Name
+      $expiryDate = $licenseFileName.Substring($licenseFileName.LastIndexOf('_') + 1)
+      if (-not $latestExpiryDate -or $expiryDate -gt $latestExpiryDate) {
+        $latestExpiryDate = $expiryDate
+        $latestFile = $_.FullName
+      }
+    }
+  }
+  return $latestFile
+}
+
+if (-not (Test-Path -Path $licensePath)) {
+  Write-Host "License folder '$licensePath' does not exist."
+  exit 1
+}
+
+$licenseFiles = Get-ChildItem -Path $licensePath | Where-Object { $_.Name -match '^[^_]*_BC\d{2}_[^_]*_Expires_\d{4}-\d{2}-\d{2}\.flf$' }
+$latestFile = Get-LatestLicenseFile -licenseFiles $licenseFiles
+
+Write-Host "Latest license file: $latestFile"
+
+Import-NAVServerLicense -ServerInstance $serverInstance -LicenseFile $latestFile
+Restart-NAVServerInstance -ServerInstance $serverInstance


### PR DESCRIPTION
This pull request adds a new PowerShell script, `Import-LatestNAVLicense.ps1`, which allows for importing the latest NAV license file. The script takes two mandatory parameters: `$serverInstance` and `$licensePath`. It first checks if the specified license folder exists, and then retrieves the latest license file based on the expiry date. Finally, it imports the license file using the `Import-NAVServerLicense` cmdlet and restarts the NAV server instance using the `Restart-NAVServerInstance` cmdlet.