### PR TITLE
"Fix error when getting AppId from dependencies"

### DIFF
--- a/powershell/Update-NAVApp.ps1
+++ b/powershell/Update-NAVApp.ps1
@@ -64,7 +64,18 @@ function Get-AppId() {
         [Parameter(Mandatory = $true, Position = 0)]
         $appInfo
     )
-    return $appInfo.AppId.Value.Guid
+
+    if (-not $appInfo.PSObject.Properties.Name -contains 'AppId') {
+        throw "AppInfo is missing the parameter 'AppId' - type: $($appInfo.GetType().FullName)"
+    }
+
+    $appId = $appInfo.AppId
+
+    switch ($true) {
+        ($appId -is [System.Guid]) { return $appId }
+        ($appId -is [Microsoft.Dynamics.Nav.Apps.Types.AppId]) { return $appId.Value }
+        default { throw "AppId is not a valid type: $($appId.GetType().FullName)" }
+    }
 }
 
 function Initialize-ColorStyle() {


### PR DESCRIPTION
This pull request fixes an error that occurs when getting the AppId from dependencies. The code now properly handles the different types of `$appInfo`, and any cases when it's missing the parameter 'AppId'.
In addition, this PR includes multiple changes to "Update-NAVApp.ps1" for better error handling and type validation"